### PR TITLE
Make Trait search go up the inheritance tree

### DIFF
--- a/ORM/Uploadable/UploadableListener.php
+++ b/ORM/Uploadable/UploadableListener.php
@@ -182,7 +182,13 @@ class UploadableListener implements EventSubscriber
      */
     private function isEntitySupported(ClassMetadata $classMetadata)
     {
-        $traitNames = $classMetadata->reflClass->getTraitNames();
+        $traitNames = [];
+
+        $class = $classMetadata->reflClass;
+        while ($class) {
+            $traitNames = array_merge($traitNames, $class->getTraitNames());
+            $class = $class->getParentClass();
+        }
 
         return in_array('Unifik\DoctrineBehaviorsBundle\Model\Uploadable\Uploadable', $traitNames);
     }


### PR DESCRIPTION
Currently to determine if an entity is uploadable the class is checked for the presence of the uploadable trait. The technique used doesn't take into account a parent class having the trait.
