### PR TITLE
[Doctrine\DBAL\Schema\SchemaException]

### DIFF
--- a/Resources/config/doctrine/Tag.orm.yml
+++ b/Resources/config/doctrine/Tag.orm.yml
@@ -6,7 +6,7 @@ Unifik\DoctrineBehaviorsBundle\Entity\Tag:
       columns: [name]
   uniqueConstraints:
     tag_unique_index:
-      columns: [name, resource_type, locale]
+      columns: [name, resourceType, locale]
   fields:
     id:
       type: integer

--- a/Resources/config/doctrine/Tagging.orm.yml
+++ b/Resources/config/doctrine/Tagging.orm.yml
@@ -2,7 +2,7 @@ Unifik\DoctrineBehaviorsBundle\Entity\Tagging:
   type: entity
   uniqueConstraints:
     tagging_unique_index:
-      columns: [tag_id, resource_type, resource_id]
+      columns: [tag_id, resourceType, resourceId]
   fields:
     id:
       type: integer


### PR DESCRIPTION
After connect Bundle to Symfony 2.7 library throws few exceptions:
```
 There is no column with name 'resource_type' on table 'Tag'.
```
```
There is no column with name 'resource_id' on table 'Tagging'.
```
```
There is no column with name 'resource_type' on table 'Tagging'.
```

To fix it, i've changed column names in yaml files to CamelCase.