### PR TITLE
Revert "[Doctrine\DBAL\Schema\SchemaException]"

### DIFF
--- a/Resources/config/doctrine/Tag.orm.yml
+++ b/Resources/config/doctrine/Tag.orm.yml
@@ -6,7 +6,7 @@ Unifik\DoctrineBehaviorsBundle\Entity\Tag:
       columns: [name]
   uniqueConstraints:
     tag_unique_index:
-      columns: [name, resourceType, locale]
+      columns: [name, resource_type, locale]
   fields:
     id:
       type: integer

--- a/Resources/config/doctrine/Tagging.orm.yml
+++ b/Resources/config/doctrine/Tagging.orm.yml
@@ -2,7 +2,7 @@ Unifik\DoctrineBehaviorsBundle\Entity\Tagging:
   type: entity
   uniqueConstraints:
     tagging_unique_index:
-      columns: [tag_id, resourceType, resourceId]
+      columns: [tag_id, resource_type, resource_id]
   fields:
     id:
       type: integer


### PR DESCRIPTION
As mentionned by pascallapointe, this should be reverted as it raises Exceptions in every Unifik based project.
https://github.com/egzakt/UnifikDoctrineBehaviorsBundle/pull/44